### PR TITLE
brickpi: fix port preparation for non-i2c devices

### DIFF
--- a/sensors.go
+++ b/sensors.go
@@ -138,7 +138,10 @@ func sensorFor(port, mode, driver string, setDev bool, addr int) (*ev3dev.Sensor
 		}
 	}
 
-	s, err := ev3dev.SensorFor(fmt.Sprintf("%s:i2c%d", port, addr), driver)
+	if mode == "nxt-i2c" {
+		port = fmt.Sprintf("%s:i2c%d", port, addr)
+	}
+	s, err := ev3dev.SensorFor(port, driver)
 	if err != nil {
 		p.SetMode("none")
 		return nil, err


### PR DESCRIPTION
@dlech Please take a look.

It seems that this doesn't always work — maybe a timing thing since sometime the first invocation of the example fails to find the sensor.